### PR TITLE
Add FastAPI REST API with Cloud Run deployment and CLI integration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,59 @@
+# Git
+.git
+.gitignore
+
+# Python
+__pycache__
+*.py[cod]
+*$py.class
+*.so
+.Python
+.pytest_cache
+.mypy_cache
+.ruff_cache
+*.egg-info
+dist
+build
+.eggs
+
+# Virtual environments
+.env
+.venv
+venv
+ENV
+
+# IDE
+.idea
+.vscode
+*.swp
+*.swo
+
+# Testing
+.coverage
+htmlcov
+.tox
+
+# Documentation build output
+site
+
+# Generated output (not needed in container)
+output
+*.pptx
+!templates/*.pptx
+
+# Local config
+.env.local
+*.local
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Development files
+tests
+examples
+docs
+mkdocs.yml
+CLAUDE.md
+*.md
+!README.md

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ venv/
 
 # MkDocs
 site/
+tmpclaude-*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+# Dockerfile for Power API - Cloud Run deployment
+#
+# Build:
+#   docker build -t power-api .
+#
+# Run locally:
+#   docker run -p 8080:8080 power-api
+#
+# Deploy to Cloud Run:
+#   gcloud run deploy power-api --source .
+
+FROM python:3.11-slim
+
+# Set environment variables
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PORT=8080
+
+WORKDIR /app
+
+# Install system dependencies (minimal for python-pptx)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy dependency files first (for better caching)
+COPY pyproject.toml .
+COPY README.md .
+
+# Copy source code
+COPY src/ src/
+
+# Install the package with API dependencies
+RUN pip install --no-cache-dir . fastapi[standard] uvicorn[standard]
+
+# Copy templates (if you want built-in templates available)
+COPY templates/ templates/
+
+# Expose the port Cloud Run expects
+EXPOSE 8080
+
+# Health check for container orchestration
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8080/health')" || exit 1
+
+# Run the FastAPI app with uvicorn
+CMD ["uvicorn", "power.api:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# Deploy Power API to Google Cloud Run
+#
+# Prerequisites:
+#   1. Google Cloud CLI installed: https://cloud.google.com/sdk/docs/install
+#   2. Authenticated: gcloud auth login
+#   3. Project set: gcloud config set project YOUR_PROJECT_ID
+#
+# Usage:
+#   chmod +x deploy.sh
+#   ./deploy.sh
+
+set -e
+
+# Configuration - modify these values
+PROJECT_ID="${GCP_PROJECT_ID:-$(gcloud config get-value project)}"
+REGION="${GCP_REGION:-us-central1}"
+SERVICE_NAME="power-api"
+
+echo "=== Power API Deployment to Cloud Run ==="
+echo "Project: $PROJECT_ID"
+echo "Region: $REGION"
+echo "Service: $SERVICE_NAME"
+echo ""
+
+# Check prerequisites
+if ! command -v gcloud &> /dev/null; then
+    echo "Error: gcloud CLI not installed"
+    echo "Install from: https://cloud.google.com/sdk/docs/install"
+    exit 1
+fi
+
+if [ -z "$PROJECT_ID" ]; then
+    echo "Error: No project ID set"
+    echo "Run: gcloud config set project YOUR_PROJECT_ID"
+    exit 1
+fi
+
+# Enable required APIs
+echo "Enabling required APIs..."
+gcloud services enable run.googleapis.com --quiet
+gcloud services enable cloudbuild.googleapis.com --quiet
+gcloud services enable artifactregistry.googleapis.com --quiet
+
+# Deploy directly from source (Cloud Build handles Docker)
+echo ""
+echo "Deploying to Cloud Run..."
+gcloud run deploy "$SERVICE_NAME" \
+    --source . \
+    --region "$REGION" \
+    --platform managed \
+    --allow-unauthenticated \
+    --memory 512Mi \
+    --cpu 1 \
+    --min-instances 0 \
+    --max-instances 10 \
+    --timeout 60s \
+    --set-env-vars="PYTHONUNBUFFERED=1"
+
+# Get the service URL
+SERVICE_URL=$(gcloud run services describe "$SERVICE_NAME" --region "$REGION" --format='value(status.url)')
+
+echo ""
+echo "=== Deployment Complete ==="
+echo "Service URL: $SERVICE_URL"
+echo ""
+echo "Test endpoints:"
+echo "  Health:  curl $SERVICE_URL/health"
+echo "  Docs:    $SERVICE_URL/"
+echo ""
+echo "Example API call:"
+cat << 'EOF'
+curl -X POST "$SERVICE_URL/generate" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "title": "Test Presentation",
+    "subtitle": "Generated via API",
+    "slides": [
+      {
+        "type": "content",
+        "title": "Hello World",
+        "bullets": ["Point 1", "Point 2"]
+      }
+    ]
+  }' \
+  --output test.pptx
+EOF

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,11 @@ docs = [
     "mkdocs-material>=9.5.0",
     "mkdocstrings[python]>=0.24.0",
 ]
+api = [
+    "fastapi>=0.109.0",
+    "uvicorn[standard]>=0.27.0",
+    "python-multipart>=0.0.6",
+]
 
 [project.scripts]
 power = "power.cli:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "rich>=13.0.0",
     "pyyaml>=6.0",
     "pillow>=10.0.0",
+    "httpx>=0.27.0",
 ]
 
 [project.optional-dependencies]

--- a/src/power/api.py
+++ b/src/power/api.py
@@ -1,0 +1,429 @@
+"""FastAPI server for Power presentation generator.
+
+Run locally:
+    uvicorn power.api:app --reload
+
+Deploy to Cloud Run:
+    See Dockerfile and deploy.sh
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from fastapi import FastAPI, HTTPException, UploadFile, File, Form
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, Field
+
+from power.core import PowerPresentation
+
+logger = logging.getLogger(__name__)
+
+app = FastAPI(
+    title="Power API",
+    description="Generate PowerPoint presentations from YAML/JSON specifications",
+    version="0.1.7",
+    docs_url="/",
+)
+
+
+# --- Pydantic Models ---
+
+class SlideSpec(BaseModel):
+    """Specification for a single slide."""
+    type: str = Field(default="content", description="Slide type: title, section, content, table, chart, image, blank")
+    title: str | None = None
+    subtitle: str | None = None
+    bullets: list[str] | None = None
+    layout: str | int | None = None
+    headers: list[str] | None = None
+    data: list[list[Any]] | None = None
+    chart_type: str | None = Field(default=None, description="Chart type: bar, line, pie")
+    categories: list[str] | None = None
+    series: dict[str, list[float]] | None = None
+    image: str | None = None
+    image_left: float | None = None
+    image_top: float | None = None
+    image_width: float | None = None
+    image_height: float | None = None
+    left: float | None = None
+    top: float | None = None
+    width: float | None = None
+    height: float | None = None
+    note: str | None = None
+    placeholder_images: dict[str, str] | None = None
+
+
+class PresentationSpec(BaseModel):
+    """Full presentation specification."""
+    title: str | None = Field(default=None, description="Title slide title")
+    subtitle: str | None = Field(default=None, description="Title slide subtitle")
+    slides: list[SlideSpec] = Field(default_factory=list)
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "title": "My Presentation",
+                    "subtitle": "Created with Power API",
+                    "slides": [
+                        {
+                            "type": "content",
+                            "title": "Key Points",
+                            "bullets": ["First point", "Second point", "Third point"]
+                        },
+                        {
+                            "type": "section",
+                            "title": "Next Section"
+                        },
+                        {
+                            "type": "chart",
+                            "title": "Sales Data",
+                            "chart_type": "bar",
+                            "categories": ["Q1", "Q2", "Q3", "Q4"],
+                            "series": {"Revenue": [100, 150, 120, 180]}
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+
+
+class HealthResponse(BaseModel):
+    """Health check response."""
+    status: str
+    version: str
+
+
+# --- Helper Functions ---
+
+def _build_from_spec(ppt: PowerPresentation, spec: dict[str, Any]) -> None:
+    """Build presentation from specification dict.
+
+    This is adapted from cli.py to work with dict input.
+    """
+    from pptx.util import Inches
+
+    # Handle title slide if top-level title exists
+    if spec.get("title"):
+        ppt.add_title_slide(spec.get("title", ""), spec.get("subtitle", ""))
+
+    # Process each slide
+    for slide_spec in spec.get("slides", []):
+        slide_type = slide_spec.get("type", "content")
+        builder = None
+
+        if slide_type == "title":
+            builder = ppt.add_title_slide(
+                slide_spec.get("title", ""),
+                slide_spec.get("subtitle", ""),
+            )
+
+        elif slide_type == "section":
+            builder = ppt.add_section_slide(
+                slide_spec.get("title", ""),
+                slide_spec.get("subtitle", ""),
+            )
+
+        elif slide_type == "content":
+            layout = slide_spec.get("layout")
+            builder = ppt.add_content_slide(
+                slide_spec.get("title", ""),
+                slide_spec.get("bullets"),
+                layout=layout,
+            )
+            # Support optional image in content slides
+            image_path = slide_spec.get("image")
+            if image_path:
+                left = slide_spec.get("image_left", 7)
+                top = slide_spec.get("image_top", 1.5)
+                width = slide_spec.get("image_width", 5)
+                height = slide_spec.get("image_height")
+
+                kwargs = {
+                    "left": Inches(left),
+                    "top": Inches(top),
+                    "width": Inches(width),
+                }
+                if height is not None:
+                    kwargs["height"] = Inches(height)
+
+                builder.add_image(image_path, **kwargs)
+
+        elif slide_type == "table":
+            title_only_layout = ppt.find_title_only_layout()
+            builder = ppt.add_slide(title_only_layout)
+            builder.set_title(slide_spec.get("title", ""))
+            builder.add_table(
+                slide_spec.get("data", []),
+                slide_spec.get("headers"),
+            )
+
+        elif slide_type == "chart":
+            title_only_layout = ppt.find_title_only_layout()
+            builder = ppt.add_slide(title_only_layout)
+            builder.set_title(slide_spec.get("title", ""))
+            chart_type = slide_spec.get("chart_type", "bar")
+            categories = slide_spec.get("categories", [])
+            series = slide_spec.get("series", {})
+
+            if chart_type == "pie":
+                values = list(series.values())[0] if series else []
+                builder.add_pie_chart(categories, values)
+            elif chart_type == "line":
+                builder.add_line_chart(categories, series)
+            else:
+                builder.add_bar_chart(categories, series)
+
+        elif slide_type == "image":
+            title_only_layout = ppt.find_title_only_layout()
+            builder = ppt.add_slide(title_only_layout)
+            if slide_spec.get("title"):
+                builder.set_title(slide_spec["title"])
+
+            image_path = slide_spec.get("image") or slide_spec.get("path")
+            if image_path:
+                left = slide_spec.get("left")
+                top = slide_spec.get("top")
+                width = slide_spec.get("width")
+                height = slide_spec.get("height")
+
+                left = Inches(left) if left is not None else None
+                top = Inches(top) if top is not None else None
+                width = Inches(width) if width is not None else None
+                height = Inches(height) if height is not None else None
+
+                kwargs = {}
+                if left is not None:
+                    kwargs["left"] = left
+                if top is not None:
+                    kwargs["top"] = top
+                if width is not None:
+                    kwargs["width"] = width
+                if height is not None:
+                    kwargs["height"] = height
+
+                builder.add_image(image_path, **kwargs)
+
+        elif slide_type == "blank":
+            builder = ppt.add_blank_slide()
+
+        # Add speaker notes if specified
+        if builder and slide_spec.get("note"):
+            builder.add_note(slide_spec["note"])
+
+
+def _generate_pptx_bytes(spec: dict[str, Any], template_bytes: bytes | None = None) -> bytes:
+    """Generate presentation and return as bytes."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        template_path = None
+
+        # Save template if provided
+        if template_bytes:
+            template_path = Path(tmpdir) / "template.pptx"
+            template_path.write_bytes(template_bytes)
+
+        # Create presentation
+        ppt = PowerPresentation(template=template_path)
+
+        if template_path:
+            ppt.clear_slides()
+
+        # Build from spec
+        _build_from_spec(ppt, spec)
+
+        # Save to bytes
+        output_path = Path(tmpdir) / "output.pptx"
+        ppt.save(output_path)
+
+        return output_path.read_bytes()
+
+
+# --- API Endpoints ---
+
+@app.get("/health", response_model=HealthResponse, tags=["System"])
+async def health_check():
+    """Health check endpoint for Cloud Run."""
+    return HealthResponse(status="healthy", version="0.1.7")
+
+
+@app.post("/generate", tags=["Generate"])
+async def generate_presentation(
+    spec: PresentationSpec,
+    filename: str = "presentation.pptx"
+) -> StreamingResponse:
+    """Generate a PowerPoint presentation from a JSON specification.
+
+    Returns the generated .pptx file as a download.
+
+    Example request body:
+    ```json
+    {
+        "title": "My Presentation",
+        "subtitle": "Created with Power API",
+        "slides": [
+            {
+                "type": "content",
+                "title": "Key Points",
+                "bullets": ["First point", "Second point"]
+            }
+        ]
+    }
+    ```
+    """
+    try:
+        spec_dict = spec.model_dump(exclude_none=True)
+        pptx_bytes = _generate_pptx_bytes(spec_dict)
+
+        return StreamingResponse(
+            io.BytesIO(pptx_bytes),
+            media_type="application/vnd.openxmlformats-officedocument.presentationml.presentation",
+            headers={
+                "Content-Disposition": f'attachment; filename="{filename}"'
+            }
+        )
+    except Exception as e:
+        logger.exception("Failed to generate presentation")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.post("/generate-with-template", tags=["Generate"])
+async def generate_with_template(
+    template: UploadFile = File(..., description="Template .pptx file"),
+    spec: str = Form(..., description="JSON specification for slides"),
+    filename: str = Form(default="presentation.pptx", description="Output filename")
+) -> StreamingResponse:
+    """Generate a presentation using an uploaded template.
+
+    Upload a .pptx template file and provide a JSON specification.
+    The template's styling will be preserved.
+    """
+    import json
+
+    try:
+        # Validate template file
+        if not template.filename or not template.filename.endswith(".pptx"):
+            raise HTTPException(status_code=400, detail="Template must be a .pptx file")
+
+        # Parse spec
+        try:
+            spec_dict = json.loads(spec)
+        except json.JSONDecodeError as e:
+            raise HTTPException(status_code=400, detail=f"Invalid JSON spec: {e}")
+
+        # Read template
+        template_bytes = await template.read()
+
+        # Generate
+        pptx_bytes = _generate_pptx_bytes(spec_dict, template_bytes)
+
+        return StreamingResponse(
+            io.BytesIO(pptx_bytes),
+            media_type="application/vnd.openxmlformats-officedocument.presentationml.presentation",
+            headers={
+                "Content-Disposition": f'attachment; filename="{filename}"'
+            }
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception("Failed to generate presentation with template")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.post("/inspect", tags=["Utilities"])
+async def inspect_template(
+    template: UploadFile = File(..., description="Template .pptx file to inspect")
+) -> dict[str, Any]:
+    """Inspect a PowerPoint template.
+
+    Upload a .pptx file to see its available layouts and placeholders.
+    Useful for understanding how to use the template in generation.
+    """
+    try:
+        if not template.filename or not template.filename.endswith(".pptx"):
+            raise HTTPException(status_code=400, detail="File must be a .pptx")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            template_path = Path(tmpdir) / "template.pptx"
+            template_path.write_bytes(await template.read())
+
+            ppt = PowerPresentation(template=template_path)
+            info = ppt.get_template_info()
+
+            # Convert non-JSON-serializable values
+            info["slide_width"] = str(info["slide_width"])
+            info["slide_height"] = str(info["slide_height"])
+            info["template"] = template.filename
+
+            return info
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception("Failed to inspect template")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+# --- Batch Processing ---
+
+class BatchItem(BaseModel):
+    """Single item in a batch generation request."""
+    spec: PresentationSpec
+    filename: str = "presentation.pptx"
+
+
+class BatchRequest(BaseModel):
+    """Batch generation request."""
+    items: list[BatchItem] = Field(..., max_length=50, description="Up to 50 presentations per batch")
+
+
+@app.post("/batch/generate", tags=["Batch"])
+async def batch_generate(request: BatchRequest) -> dict[str, Any]:
+    """Generate multiple presentations in a single request.
+
+    Returns a summary with download URLs (for Cloud Storage integration)
+    or base64-encoded files for smaller batches.
+
+    Note: For large batches, consider using Cloud Tasks or Pub/Sub
+    for async processing.
+    """
+    import base64
+
+    results = []
+    errors = []
+
+    for i, item in enumerate(request.items):
+        try:
+            spec_dict = item.spec.model_dump(exclude_none=True)
+            pptx_bytes = _generate_pptx_bytes(spec_dict)
+
+            results.append({
+                "index": i,
+                "filename": item.filename,
+                "size_bytes": len(pptx_bytes),
+                "data_base64": base64.b64encode(pptx_bytes).decode("utf-8")
+            })
+        except Exception as e:
+            errors.append({
+                "index": i,
+                "filename": item.filename,
+                "error": str(e)
+            })
+
+    return {
+        "total": len(request.items),
+        "successful": len(results),
+        "failed": len(errors),
+        "results": results,
+        "errors": errors
+    }
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8080)


### PR DESCRIPTION
## Summary

- Add FastAPI REST API for generating presentations via HTTP
- Deploy to Google Cloud Run (live at https://power-api-944767079044.us-central1.run.app)
- Add `power cloud` CLI subcommand to access the API from the command line

## New Files

| File | Purpose |
|------|---------|
| `src/power/api.py` | FastAPI application with REST endpoints |
| `Dockerfile` | Container config for Cloud Run |
| `deploy.sh` | One-command GCP deployment script |
| `.dockerignore` | Optimized container builds |

## API Endpoints

| Endpoint | Method | Description |
|----------|--------|-------------|
| `/` | GET | Swagger UI documentation |
| `/health` | GET | Health check |
| `/generate` | POST | Generate PPTX from JSON spec |
| `/generate-with-template` | POST | Generate with uploaded template |
| `/inspect` | POST | Inspect template layouts |
| `/batch/generate` | POST | Batch generation (up to 50) |

## CLI Commands

```bash
power cloud health                    # Check API status
power cloud generate spec.yaml -o out.pptx   # Generate via cloud
power cloud inspect template.pptx     # Inspect via cloud
```

## Closes

- Closes #4 (Add REST endpoints with FastAPI)
- Closes #14 (Investigate Cloud deployment)

## Test Plan

- [x] Local API testing with uvicorn
- [x] Cloud Run deployment verified
- [x] CLI `power cloud health` tested
- [x] CLI `power cloud generate` tested
- [x] CLI `power cloud generate -t` with template tested
- [x] CLI `power cloud inspect` tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)